### PR TITLE
fix: import onError from @orpc/server

### DIFF
--- a/app/api/orpc/[[...rest]]/route.ts
+++ b/app/api/orpc/[[...rest]]/route.ts
@@ -1,5 +1,5 @@
 import { RPCHandler } from '@orpc/server/fetch'
-import { onError } from '@orpc/shared'
+import { onError } from '@orpc/server'
 import { appRouter } from '@/lib/orpc/router'
 import { createContext } from '@/lib/orpc/context'
 

--- a/lib/orpc/router.ts
+++ b/lib/orpc/router.ts
@@ -1,4 +1,4 @@
-import { os, ORPCError } from '@orpc/server'
+import { ORPCError } from '@orpc/server'
 import { publicProcedure } from './base'
 import { z } from 'zod'
 import { shipmentSchema } from '@/lib/validations'


### PR DESCRIPTION
## Problem
Build was failing because `@orpc/shared` is not a direct dependency.

## Solution
- Import `onError` from `@orpc/server` which re-exports it
- Remove unused `os` import from router.ts

## Testing
- ✅ `npm run build` passes
- ✅ `npm run dev` works (no Turbopack panic)