### PR TITLE
refactor: split AI extraction into tracking + metadata prompts

### DIFF
--- a/lib/infrastructure/sdks/extraction/modules/shipping/schemas.ts
+++ b/lib/infrastructure/sdks/extraction/modules/shipping/schemas.ts
@@ -9,12 +9,13 @@ import { z } from 'zod'
  */
 
 // ============================================
-// Schema 1: Tracking Numbers (strict)
+// Schema 1: Tracking Numbers + Shipped Date
 // ============================================
 
 export const ExtractedTrackingSchema = z.object({
   trackingNumber: z.string().min(1, 'Tracking number required'),
   carrier: z.enum(['ups', 'usps', 'fedex', 'dhl', 'other']),
+  shippedDate: z.string(),  // Empty string if not found, ISO format (YYYY-MM-DD) if found
   confidence: z.number().min(0).max(1),
 })
 
@@ -26,13 +27,12 @@ export type ExtractedTracking = z.infer<typeof ExtractedTrackingSchema>
 export type TrackingOnlyResult = z.infer<typeof TrackingOnlyResultSchema>
 
 // ============================================
-// Schema 2: Metadata (supplier, PO, dates)
+// Schema 2: Metadata (supplier, PO)
 // ============================================
 
 export const MetadataExtractionSchema = z.object({
   supplier: z.string(),  // Empty string if not found
   poNumber: z.string(),  // Empty string if not found
-  shippedDate: z.string(),  // Empty string if not found, ISO format if found
 })
 
 export type MetadataExtraction = z.infer<typeof MetadataExtractionSchema>

--- a/lib/infrastructure/sdks/extraction/modules/shipping/tracking.ts
+++ b/lib/infrastructure/sdks/extraction/modules/shipping/tracking.ts
@@ -175,7 +175,6 @@ export async function extractTracking(
     console.log('[Extraction] Metadata:', {
       supplier: metadata.supplier || '(none)',
       poNumber: metadata.poNumber || '(none)',
-      shippedDate: metadata.shippedDate || '(none)',
     })
 
     // Combine results
@@ -183,7 +182,7 @@ export async function extractTracking(
       trackingNumber: tracking.trackingNumber,
       carrier: tracking.carrier,
       poNumber: metadata.poNumber || '',
-      shippedDate: metadata.shippedDate || '',
+      shippedDate: tracking.shippedDate || '',  // Shipped date comes from tracking extraction
       confidence: tracking.confidence,
     }))
 


### PR DESCRIPTION
## Problem
The AI extraction was extracting false positive tracking numbers (e.g., `1830702741` which was likely a reference/order number, not a DHL tracking number).

## Solution
Split the single AI extraction call into two focused prompts:

### Prompt 1: Tracking Numbers Only
- Strict format validation rules for each carrier
- Explicit "what NOT to extract" section (phone numbers, PO numbers, order IDs, etc.)
- Higher confidence threshold
- Post-extraction regex validation

### Prompt 2: Metadata (Supplier, PO, Dates)
- Only called if tracking numbers are found
- Focused on reading comprehension, not pattern matching
- Saves API calls when no tracking found

## Changes
- `schemas.ts`: Added separate schemas for each extraction step
- `prompts.ts`: Split into `buildTrackingOnlyPrompt` + `buildMetadataPrompt`
- `tracking.ts`: Two-step extraction with validation between steps

## Validation Added
- Regex validation per carrier format
- Confidence threshold (reject < 0.7)
- Strip carrier prefixes
- Reject phone number patterns for DHL