### PR TITLE
feat(notifications): add notification system schema

### DIFF
--- a/prisma/migrations/20260213233228_notification_system/migration.sql
+++ b/prisma/migrations/20260213233228_notification_system/migration.sql
@@ -1,0 +1,120 @@
+-- CreateEnum
+CREATE TYPE "NotificationChannel" AS ENUM ('EMAIL', 'SLACK', 'WEBHOOK', 'SMS');
+
+-- CreateEnum
+CREATE TYPE "NotificationStatus" AS ENUM ('PENDING', 'PROCESSING', 'SENT', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "notification_templates" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "channel" "NotificationChannel" NOT NULL,
+    "subject" TEXT,
+    "body" TEXT NOT NULL,
+    "metadata" JSONB,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notification_templates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notification_rules" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "trigger_event" TEXT NOT NULL,
+    "filter" JSONB,
+    "template_id" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notification_rules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notification_recipients" (
+    "id" TEXT NOT NULL,
+    "rule_id" TEXT NOT NULL,
+    "channel" "NotificationChannel" NOT NULL,
+    "target" TEXT NOT NULL,
+    "metadata" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notification_recipients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notification_queue" (
+    "id" TEXT NOT NULL,
+    "rule_id" TEXT,
+    "event_id" TEXT,
+    "channel" "NotificationChannel" NOT NULL,
+    "recipient" TEXT NOT NULL,
+    "subject" TEXT,
+    "body" TEXT NOT NULL,
+    "metadata" JSONB,
+    "status" "NotificationStatus" NOT NULL DEFAULT 'PENDING',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "max_attempts" INTEGER NOT NULL DEFAULT 5,
+    "available_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "locked_at" TIMESTAMP(3),
+    "sent_at" TIMESTAMP(3),
+    "last_error" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notification_queue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notification_log" (
+    "id" TEXT NOT NULL,
+    "queue_id" TEXT,
+    "channel" "NotificationChannel" NOT NULL,
+    "recipient" TEXT NOT NULL,
+    "subject" TEXT,
+    "body" TEXT NOT NULL,
+    "status" "NotificationStatus" NOT NULL,
+    "provider_id" TEXT,
+    "metadata" JSONB,
+    "sent_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notification_log_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "notification_templates_name_key" ON "notification_templates"("name");
+
+-- CreateIndex
+CREATE INDEX "notification_rules_trigger_event_idx" ON "notification_rules"("trigger_event");
+
+-- CreateIndex
+CREATE INDEX "notification_rules_enabled_idx" ON "notification_rules"("enabled");
+
+-- CreateIndex
+CREATE INDEX "notification_recipients_rule_id_idx" ON "notification_recipients"("rule_id");
+
+-- CreateIndex
+CREATE INDEX "notification_queue_channel_status_idx" ON "notification_queue"("channel", "status");
+
+-- CreateIndex
+CREATE INDEX "notification_queue_available_at_idx" ON "notification_queue"("available_at");
+
+-- CreateIndex
+CREATE INDEX "notification_log_channel_idx" ON "notification_log"("channel");
+
+-- CreateIndex
+CREATE INDEX "notification_log_sent_at_idx" ON "notification_log"("sent_at");
+
+-- CreateIndex
+CREATE INDEX "notification_log_recipient_idx" ON "notification_log"("recipient");
+
+-- AddForeignKey
+ALTER TABLE "notification_rules" ADD CONSTRAINT "notification_rules_template_id_fkey" FOREIGN KEY ("template_id") REFERENCES "notification_templates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notification_recipients" ADD CONSTRAINT "notification_recipients_rule_id_fkey" FOREIGN KEY ("rule_id") REFERENCES "notification_rules"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,3 +111,107 @@ enum EventStatus {
   COMPLETED
   FAILED
 }
+
+// ============================================================================
+// Notification System
+// ============================================================================
+
+enum NotificationChannel {
+  EMAIL
+  SLACK
+  WEBHOOK
+  SMS
+}
+
+enum NotificationStatus {
+  PENDING
+  PROCESSING
+  SENT
+  FAILED
+}
+
+model notification_templates {
+  id          String              @id @default(cuid())
+  name        String              @unique
+  channel     NotificationChannel
+  subject     String?             // For email
+  body        String              // Template body (Handlebars syntax)
+  metadata    Json?               // Channel-specific metadata (e.g., Slack block kit)
+  enabled     Boolean             @default(true)
+  created_at  DateTime            @default(now())
+  updated_at  DateTime            @updatedAt
+
+  rules       notification_rules[]
+}
+
+model notification_rules {
+  id            String              @id @default(cuid())
+  name          String
+  description   String?
+  trigger_event String              // e.g., "shipment.delivered", "shipment.exception"
+  filter        Json?               // Optional JSONPath/predicate to filter events
+  template_id   String
+  enabled       Boolean             @default(true)
+  created_at    DateTime            @default(now())
+  updated_at    DateTime            @updatedAt
+
+  template      notification_templates @relation(fields: [template_id], references: [id], onDelete: Cascade)
+  recipients    notification_recipients[]
+
+  @@index([trigger_event])
+  @@index([enabled])
+}
+
+model notification_recipients {
+  id         String              @id @default(cuid())
+  rule_id    String
+  channel    NotificationChannel
+  target     String              // Email address, Slack channel ID, webhook URL, phone number
+  metadata   Json?               // Additional recipient-specific data
+  created_at DateTime            @default(now())
+  updated_at DateTime            @updatedAt
+
+  rule       notification_rules  @relation(fields: [rule_id], references: [id], onDelete: Cascade)
+
+  @@index([rule_id])
+}
+
+model notification_queue {
+  id           String             @id @default(cuid())
+  rule_id      String?
+  event_id     String?            // Reference to source event_queue.id
+  channel      NotificationChannel
+  recipient    String             // Target address/channel
+  subject      String?
+  body         String
+  metadata     Json?              // Rendered payload, attachments, etc.
+  status       NotificationStatus @default(PENDING)
+  attempts     Int                @default(0)
+  max_attempts Int                @default(5)
+  available_at DateTime           @default(now())
+  locked_at    DateTime?
+  sent_at      DateTime?
+  last_error   String?
+  created_at   DateTime           @default(now())
+  updated_at   DateTime           @updatedAt
+
+  @@index([channel, status])
+  @@index([available_at])
+}
+
+model notification_log {
+  id           String              @id @default(cuid())
+  queue_id     String?             // Reference to notification_queue.id
+  channel      NotificationChannel
+  recipient    String
+  subject      String?
+  body         String
+  status       NotificationStatus
+  provider_id  String?             // External provider message ID (e.g., SES message ID)
+  metadata     Json?
+  sent_at      DateTime            @default(now())
+
+  @@index([channel])
+  @@index([sent_at])
+  @@index([recipient])
+}


### PR DESCRIPTION
## Summary
Adds the database foundation for the notification system.

## Tables Added
- **notification_templates**: Channel-specific message templates (Handlebars syntax)
- **notification_rules**: Map domain events to templates and recipients
- **notification_recipients**: Recipients per rule (email, Slack, webhook, SMS)
- **notification_queue**: Durable queue for outbound notifications (retry semantics)
- **notification_log**: Audit trail of sent notifications

## Enums
- `NotificationChannel`: EMAIL, SLACK, WEBHOOK, SMS
- `NotificationStatus`: PENDING, PROCESSING, SENT, FAILED

## Next PRs
1. NotificationService interface + adapters
2. Rule evaluator + queue insertion
3. Channel workers
4. Wire shipment handlers