### PR TITLE
feat(notifications): add notification service infrastructure

### DIFF
--- a/lib/application/notifications/ChannelAdapter.ts
+++ b/lib/application/notifications/ChannelAdapter.ts
@@ -1,0 +1,7 @@
+import type { NotificationChannel } from '@prisma/client'
+import type { NotificationPayload, SendResult } from './types'
+
+export interface ChannelAdapter {
+  channel: NotificationChannel
+  send(payload: NotificationPayload): Promise<SendResult>
+}

--- a/lib/application/notifications/NotificationQueue.ts
+++ b/lib/application/notifications/NotificationQueue.ts
@@ -1,0 +1,20 @@
+import type { NotificationChannel } from '@prisma/client'
+import type { NotificationPayload, QueuedNotification } from './types'
+
+export type EnqueueOptions = {
+  ruleId?: string
+  eventId?: string
+  scheduledFor?: Date
+}
+
+export type ClaimOptions = {
+  batchSize?: number
+  visibilityTimeoutMs?: number
+}
+
+export interface NotificationQueue {
+  enqueue(payloads: NotificationPayload[], options?: EnqueueOptions): Promise<void>
+  claim(channel: NotificationChannel, options?: ClaimOptions): Promise<QueuedNotification[]>
+  markSent(ids: string[], providerId?: string): Promise<void>
+  markFailed(id: string, error: string, retryAt?: Date): Promise<void>
+}

--- a/lib/application/notifications/NotificationService.ts
+++ b/lib/application/notifications/NotificationService.ts
@@ -1,0 +1,5 @@
+import type { NotificationPayload, SendResult } from './types'
+
+export interface NotificationService {
+  send(payload: NotificationPayload): Promise<SendResult>
+}

--- a/lib/application/notifications/renderTemplate.ts
+++ b/lib/application/notifications/renderTemplate.ts
@@ -1,0 +1,10 @@
+import Handlebars from 'handlebars'
+import type { TemplateData } from './types'
+
+/**
+ * Render a Handlebars template with the given data.
+ */
+export function renderTemplate(template: string, data: TemplateData): string {
+  const compiled = Handlebars.compile(template)
+  return compiled(data)
+}

--- a/lib/application/notifications/types.ts
+++ b/lib/application/notifications/types.ts
@@ -1,0 +1,33 @@
+import type { NotificationChannel, NotificationStatus } from '@prisma/client'
+
+export type NotificationPayload = {
+  channel: NotificationChannel
+  recipient: string
+  subject?: string
+  body: string
+  metadata?: Record<string, unknown>
+}
+
+export type SendResult = {
+  success: boolean
+  providerId?: string
+  error?: string
+}
+
+export type QueuedNotification = {
+  id: string
+  ruleId: string | null
+  eventId: string | null
+  channel: NotificationChannel
+  recipient: string
+  subject: string | null
+  body: string
+  metadata: Record<string, unknown> | null
+  status: NotificationStatus
+  attempts: number
+  availableAt: Date
+  lockedAt: Date | null
+  lastError: string | null
+}
+
+export type TemplateData = Record<string, unknown>

--- a/lib/infrastructure/notifications/CompositeNotificationService.ts
+++ b/lib/infrastructure/notifications/CompositeNotificationService.ts
@@ -1,0 +1,29 @@
+import type { NotificationChannel } from '@prisma/client'
+import type { ChannelAdapter } from '@/lib/application/notifications/ChannelAdapter'
+import type { NotificationService } from '@/lib/application/notifications/NotificationService'
+import type { NotificationPayload, SendResult } from '@/lib/application/notifications/types'
+
+/**
+ * Composite notification service that routes to channel-specific adapters.
+ */
+export function createCompositeNotificationService(
+  adapters: ChannelAdapter[]
+): NotificationService {
+  const adapterMap = new Map<NotificationChannel, ChannelAdapter>()
+  for (const adapter of adapters) {
+    adapterMap.set(adapter.channel, adapter)
+  }
+
+  return {
+    async send(payload: NotificationPayload): Promise<SendResult> {
+      const adapter = adapterMap.get(payload.channel)
+      if (!adapter) {
+        return {
+          success: false,
+          error: `No adapter registered for channel: ${payload.channel}`,
+        }
+      }
+      return adapter.send(payload)
+    },
+  }
+}

--- a/lib/infrastructure/notifications/PrismaNotificationQueue.ts
+++ b/lib/infrastructure/notifications/PrismaNotificationQueue.ts
@@ -1,0 +1,179 @@
+import type { NotificationChannel, NotificationStatus, Prisma } from '@prisma/client'
+import type { NotificationQueue, EnqueueOptions, ClaimOptions } from '@/lib/application/notifications/NotificationQueue'
+import type { NotificationPayload, QueuedNotification } from '@/lib/application/notifications/types'
+import { prisma } from '@/lib/prisma'
+
+const DEFAULT_BATCH_SIZE = 10
+const DEFAULT_VISIBILITY_TIMEOUT_MS = 60_000
+const DEFAULT_RETRY_DELAY_MS = 30_000
+
+type NotificationQueueRow = {
+  id: string
+  rule_id: string | null
+  event_id: string | null
+  channel: NotificationChannel
+  recipient: string
+  subject: string | null
+  body: string
+  metadata: Prisma.JsonValue
+  status: NotificationStatus
+  attempts: number
+  max_attempts: number
+  available_at: Date
+  locked_at: Date | null
+  sent_at: Date | null
+  last_error: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export function createPrismaNotificationQueue(prismaClient = prisma): NotificationQueue {
+  const mapRow = (row: NotificationQueueRow): QueuedNotification => ({
+    id: row.id,
+    ruleId: row.rule_id,
+    eventId: row.event_id,
+    channel: row.channel,
+    recipient: row.recipient,
+    subject: row.subject,
+    body: row.body,
+    metadata: row.metadata as Record<string, unknown> | null,
+    status: row.status,
+    attempts: row.attempts,
+    availableAt: row.available_at,
+    lockedAt: row.locked_at,
+    lastError: row.last_error,
+  })
+
+  return {
+    async enqueue(payloads: NotificationPayload[], options?: EnqueueOptions): Promise<void> {
+      if (!payloads.length) return
+
+      await prismaClient.notification_queue.createMany({
+        data: payloads.map((payload) => ({
+          rule_id: options?.ruleId,
+          event_id: options?.eventId,
+          channel: payload.channel,
+          recipient: payload.recipient,
+          subject: payload.subject,
+          body: payload.body,
+          metadata: (payload.metadata ?? {}) as Prisma.InputJsonValue,
+          available_at: options?.scheduledFor ?? new Date(),
+        })),
+      })
+    },
+
+    async claim(channel: NotificationChannel, options?: ClaimOptions): Promise<QueuedNotification[]> {
+      const batchSize = options?.batchSize ?? DEFAULT_BATCH_SIZE
+      const visibilityTimeout = options?.visibilityTimeoutMs ?? DEFAULT_VISIBILITY_TIMEOUT_MS
+
+      if (batchSize <= 0) {
+        return []
+      }
+
+      const rows = await prismaClient.$transaction(async (tx) => {
+        const result = await tx.$queryRaw<NotificationQueueRow[]>`
+          UPDATE notification_queue
+          SET status = 'PROCESSING',
+              locked_at = NOW(),
+              attempts = attempts + 1,
+              available_at = NOW() + (${visibilityTimeout}::int * interval '1 millisecond')
+          WHERE id IN (
+            SELECT id
+            FROM notification_queue
+            WHERE channel = ${channel}::"NotificationChannel"
+              AND status IN ('PENDING', 'FAILED')
+              AND available_at <= NOW()
+              AND attempts < max_attempts
+            ORDER BY available_at ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT ${batchSize}
+          )
+          RETURNING *;
+        `
+        return result
+      })
+
+      return rows.map(mapRow)
+    },
+
+    async markSent(ids: string[], providerId?: string): Promise<void> {
+      if (!ids.length) return
+
+      await prismaClient.$transaction(async (tx) => {
+        // Update queue status
+        await tx.notification_queue.updateMany({
+          where: { id: { in: ids } },
+          data: {
+            status: 'SENT',
+            locked_at: null,
+            sent_at: new Date(),
+            last_error: null,
+          },
+        })
+
+        // Log sent notifications
+        const notifications = await tx.notification_queue.findMany({
+          where: { id: { in: ids } },
+        })
+
+        await tx.notification_log.createMany({
+          data: notifications.map((n) => ({
+            queue_id: n.id,
+            channel: n.channel,
+            recipient: n.recipient,
+            subject: n.subject,
+            body: n.body,
+            status: 'SENT',
+            provider_id: providerId,
+            metadata: n.metadata ?? undefined,
+          })),
+        })
+      })
+    },
+
+    async markFailed(id: string, error: string, retryAt?: Date): Promise<void> {
+      await prismaClient.$transaction(async (tx) => {
+        const record = await tx.notification_queue.findUnique({ where: { id } })
+        if (!record) return
+
+        const hasAttemptsRemaining = record.attempts < record.max_attempts
+
+        await tx.notification_queue.update({
+          where: { id },
+          data: {
+            status: hasAttemptsRemaining ? 'PENDING' : 'FAILED',
+            available_at: hasAttemptsRemaining
+              ? (retryAt ?? new Date(Date.now() + DEFAULT_RETRY_DELAY_MS))
+              : record.available_at,
+            locked_at: null,
+            last_error: error,
+          },
+        })
+
+        // Log failed notification if no more attempts
+        if (!hasAttemptsRemaining) {
+          await tx.notification_log.create({
+            data: {
+              queue_id: record.id,
+              channel: record.channel,
+              recipient: record.recipient,
+              subject: record.subject,
+              body: record.body,
+              status: 'FAILED',
+              metadata: record.metadata ?? undefined,
+            },
+          })
+        }
+      })
+    },
+  }
+}
+
+let instance: NotificationQueue | null = null
+
+export function getNotificationQueue(): NotificationQueue {
+  if (!instance) {
+    instance = createPrismaNotificationQueue()
+  }
+  return instance
+}

--- a/lib/infrastructure/notifications/adapters/LoggingAdapter.ts
+++ b/lib/infrastructure/notifications/adapters/LoggingAdapter.ts
@@ -1,0 +1,24 @@
+import type { NotificationChannel } from '@prisma/client'
+import type { ChannelAdapter } from '@/lib/application/notifications/ChannelAdapter'
+import type { NotificationPayload, SendResult } from '@/lib/application/notifications/types'
+
+/**
+ * Logging adapter - logs notifications to console instead of sending.
+ * Useful for development and testing.
+ */
+export function createLoggingAdapter(channel: NotificationChannel): ChannelAdapter {
+  return {
+    channel,
+    async send(payload: NotificationPayload): Promise<SendResult> {
+      console.log(`[notification:${channel}] to=${payload.recipient}`, {
+        subject: payload.subject,
+        body: payload.body.substring(0, 200),
+        metadata: payload.metadata,
+      })
+      return {
+        success: true,
+        providerId: `log-${Date.now()}`,
+      }
+    },
+  }
+}

--- a/lib/infrastructure/notifications/index.ts
+++ b/lib/infrastructure/notifications/index.ts
@@ -1,0 +1,24 @@
+import { NotificationChannel } from '@prisma/client'
+import type { NotificationService } from '@/lib/application/notifications/NotificationService'
+import { createCompositeNotificationService } from './CompositeNotificationService'
+import { createLoggingAdapter } from './adapters/LoggingAdapter'
+
+let instance: NotificationService | null = null
+
+/**
+ * Get the singleton notification service.
+ * Uses logging adapters by default; swap in real adapters (SES, Slack, etc.) via config.
+ */
+export function getNotificationService(): NotificationService {
+  if (!instance) {
+    // Default: logging adapters for all channels
+    const adapters = [
+      createLoggingAdapter(NotificationChannel.EMAIL),
+      createLoggingAdapter(NotificationChannel.SLACK),
+      createLoggingAdapter(NotificationChannel.WEBHOOK),
+      createLoggingAdapter(NotificationChannel.SMS),
+    ]
+    instance = createCompositeNotificationService(adapters)
+  }
+  return instance
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "handlebars": "^4.7.8",
         "lucide-react": "^0.563.0",
         "next": "^15.1.6",
         "openai": "^6.18.0",
@@ -9287,6 +9288,27 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -11137,6 +11159,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "15.5.12",
@@ -13149,7 +13177,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -13923,6 +13950,19 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -14484,6 +14524,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "handlebars": "^4.7.8",
     "lucide-react": "^0.563.0",
     "next": "^15.1.6",
     "openai": "^6.18.0",


### PR DESCRIPTION
## Summary
Adds the core notification service infrastructure on top of the schema from #20.

## Components

### Application Layer
- **NotificationService**: Core interface for sending notifications
- **ChannelAdapter**: Interface for channel-specific senders (email, Slack, etc.)
- **NotificationQueue**: Interface for durable notification delivery with retry semantics
- **renderTemplate**: Handlebars-based template rendering

### Infrastructure Layer
- **CompositeNotificationService**: Routes notifications to the right channel adapter
- **LoggingAdapter**: Development adapter that logs instead of sending (start with this, add real adapters later)
- **PrismaNotificationQueue**: Postgres-backed queue with atomic claiming (`FOR UPDATE SKIP LOCKED`)

## Dependencies
- Handlebars for template rendering
- Depends on #20 (notification schema)

## Next PRs
1. Rule evaluator + queue insertion (wire domain events to notification queue)
2. Channel workers (claim + send)
3. Wire shipment handlers