### PR TITLE
feat(notifications): add rule evaluator and wire to event handlers

### DIFF
--- a/lib/application/events/shipment/registerHandlers.ts
+++ b/lib/application/events/shipment/registerHandlers.ts
@@ -1,16 +1,24 @@
 import { registerEventHandler } from '@/lib/application/events/registry'
+import { evaluateAndEnqueue } from '@/lib/application/notifications/evaluateRules'
 import { ShipmentEventTopics } from './topics'
+import type { QueuedEvent } from '@/lib/application/events/types'
 
-function logHandler(topic: string) {
-  return async (event: { payload: unknown }) => {
+function createHandler(topic: string) {
+  return async (event: QueuedEvent<unknown>) => {
     console.log(`[event] ${topic}`, JSON.stringify(event.payload))
+    
+    // Evaluate notification rules and enqueue notifications
+    const result = await evaluateAndEnqueue(topic, event.id, event.payload as Record<string, unknown>)
+    if (result.notificationsQueued > 0) {
+      console.log(`[event] ${topic} -> queued ${result.notificationsQueued} notifications`)
+    }
   }
 }
 
 export function registerShipmentEventHandlers() {
-  registerEventHandler(ShipmentEventTopics.Created, logHandler(ShipmentEventTopics.Created))
-  registerEventHandler(ShipmentEventTopics.Updated, logHandler(ShipmentEventTopics.Updated))
-  registerEventHandler(ShipmentEventTopics.StatusChanged, logHandler(ShipmentEventTopics.StatusChanged))
-  registerEventHandler(ShipmentEventTopics.Delivered, logHandler(ShipmentEventTopics.Delivered))
-  registerEventHandler(ShipmentEventTopics.Exception, logHandler(ShipmentEventTopics.Exception))
+  registerEventHandler(ShipmentEventTopics.Created, createHandler(ShipmentEventTopics.Created))
+  registerEventHandler(ShipmentEventTopics.Updated, createHandler(ShipmentEventTopics.Updated))
+  registerEventHandler(ShipmentEventTopics.StatusChanged, createHandler(ShipmentEventTopics.StatusChanged))
+  registerEventHandler(ShipmentEventTopics.Delivered, createHandler(ShipmentEventTopics.Delivered))
+  registerEventHandler(ShipmentEventTopics.Exception, createHandler(ShipmentEventTopics.Exception))
 }

--- a/lib/application/notifications/evaluateRules.ts
+++ b/lib/application/notifications/evaluateRules.ts
@@ -1,0 +1,97 @@
+import type { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
+import { getNotificationQueue } from '@/lib/infrastructure/notifications/PrismaNotificationQueue'
+import { renderTemplate } from './renderTemplate'
+import type { TemplateData } from './types'
+
+/**
+ * Evaluate notification rules for a given event and enqueue notifications.
+ */
+export async function evaluateAndEnqueue(
+  triggerEvent: string,
+  eventId: string,
+  payload: TemplateData
+): Promise<{ rulesMatched: number; notificationsQueued: number }> {
+  // Find matching rules with templates and recipients
+  const rules = await prisma.notification_rules.findMany({
+    where: {
+      trigger_event: triggerEvent,
+      enabled: true,
+    },
+    include: {
+      template: true,
+      recipients: true,
+    },
+  })
+
+  let notificationsQueued = 0
+  const queue = getNotificationQueue()
+
+  for (const rule of rules) {
+    // Evaluate filter if present
+    if (rule.filter) {
+      const filterResult = evaluateFilter(rule.filter, payload)
+      if (!filterResult) continue
+    }
+
+    // Render template
+    const renderedSubject = rule.template.subject
+      ? renderTemplate(rule.template.subject, payload)
+      : null
+    const renderedBody = renderTemplate(rule.template.body, payload)
+
+    // Build notification payloads for each recipient
+    const payloads = rule.recipients.map((recipient) => ({
+      channel: recipient.channel,
+      recipient: recipient.target,
+      subject: renderedSubject,
+      body: renderedBody,
+      metadata: {
+        templateId: rule.template_id,
+        ruleId: rule.id,
+        recipientMetadata: recipient.metadata,
+        templateMetadata: rule.template.metadata,
+      },
+    }))
+
+    if (payloads.length > 0) {
+      await queue.enqueue(payloads, { ruleId: rule.id, eventId })
+      notificationsQueued += payloads.length
+    }
+  }
+
+  return { rulesMatched: rules.length, notificationsQueued }
+}
+
+/**
+ * Simple filter evaluation.
+ * Supports basic JSON predicates: { "field": "value" } for equality checks.
+ * Returns true if all conditions match.
+ */
+function evaluateFilter(filter: Prisma.JsonValue, payload: TemplateData): boolean {
+  if (!filter || typeof filter !== 'object' || Array.isArray(filter)) {
+    return true
+  }
+
+  for (const [key, expected] of Object.entries(filter)) {
+    const actual = getNestedValue(payload, key)
+    if (actual !== expected) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Get a nested value from an object using dot notation.
+ * e.g., getNestedValue({ a: { b: 1 } }, 'a.b') => 1
+ */
+function getNestedValue(obj: TemplateData, path: string): unknown {
+  return path.split('.').reduce((acc: unknown, key) => {
+    if (acc && typeof acc === 'object' && key in acc) {
+      return (acc as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
+}

--- a/lib/application/notifications/index.ts
+++ b/lib/application/notifications/index.ts
@@ -1,0 +1,6 @@
+export * from './types'
+export * from './NotificationService'
+export * from './NotificationQueue'
+export * from './ChannelAdapter'
+export * from './renderTemplate'
+export * from './evaluateRules'


### PR DESCRIPTION
## Summary
Adds rule evaluation logic that connects domain events to the notification queue.

## Components

### evaluateAndEnqueue
- Queries enabled rules matching the trigger event
- Evaluates optional JSON filters against event payload
- Renders Handlebars templates with event data
- Enqueues notifications for each recipient

### Filter Support
Simple JSON predicate matching with dot-notation paths:
```json
{ "current.status": "delivered" }
```

### Shipment Handler Integration
- Shipment event handlers now call `evaluateAndEnqueue` after logging
- Any matching notification rules will queue notifications automatically

## Dependencies
- Depends on #20 (schema) and #21 (service infrastructure)

## Next PRs
1. Channel workers (claim + send from notification_queue)
2. Sample rules/templates for shipment events