### PR TITLE
feat(notifications): add Knock workflow definitions

### DIFF
--- a/.knock/workflows/shipment-created/in_app_notification/markdown_body.md
+++ b/.knock/workflows/shipment-created/in_app_notification/markdown_body.md
@@ -1,0 +1,5 @@
+📦 **New shipment created**
+
+Tracking: {{data.trackingNumber}}
+Carrier: {{data.carrier}}
+PO: {{data.poNumber}}

--- a/.knock/workflows/shipment-created/workflow.json
+++ b/.knock/workflows/shipment-created/workflow.json
@@ -1,0 +1,25 @@
+{
+  "name": "Shipment Created",
+  "steps": [
+    {
+      "channel_key": "in-app",
+      "channel_type": "in_app_feed",
+      "name": "In-app notification",
+      "ref": "in_app_notification",
+      "template": {
+        "action_url": "/shipments/{{data.trackingNumber}}",
+        "markdown_body@": "in_app_notification/markdown_body.md"
+      },
+      "type": "channel"
+    }
+  ],
+  "trigger_frequency": "every_trigger",
+  "__readonly": {
+    "environment": "development",
+    "key": "shipment-created",
+    "active": true,
+    "valid": true,
+    "created_at": "2026-02-14T00:48:24.223870Z"
+  },
+  "$schema": "https://schemas.knock.app/cli/workflow.json"
+}

--- a/.knock/workflows/shipment-delivered/in_app_notification/markdown_body.md
+++ b/.knock/workflows/shipment-delivered/in_app_notification/markdown_body.md
@@ -1,0 +1,5 @@
+✅ **Shipment delivered!**
+
+Tracking: {{data.trackingNumber}}
+Delivered: {{data.deliveredDate}}
+PO: {{data.poNumber}}

--- a/.knock/workflows/shipment-delivered/workflow.json
+++ b/.knock/workflows/shipment-delivered/workflow.json
@@ -1,0 +1,25 @@
+{
+  "name": "Shipment Delivered",
+  "steps": [
+    {
+      "channel_key": "in-app",
+      "channel_type": "in_app_feed",
+      "name": "In-app notification",
+      "ref": "in_app_notification",
+      "template": {
+        "action_url": "/shipments/{{data.trackingNumber}}",
+        "markdown_body@": "in_app_notification/markdown_body.md"
+      },
+      "type": "channel"
+    }
+  ],
+  "trigger_frequency": "every_trigger",
+  "__readonly": {
+    "environment": "development",
+    "key": "shipment-delivered",
+    "active": true,
+    "valid": true,
+    "created_at": "2026-02-14T00:48:24.648813Z"
+  },
+  "$schema": "https://schemas.knock.app/cli/workflow.json"
+}

--- a/.knock/workflows/shipment-exception/in_app_notification/markdown_body.md
+++ b/.knock/workflows/shipment-exception/in_app_notification/markdown_body.md
@@ -1,0 +1,7 @@
+⚠️ **Shipment exception**
+
+Tracking: {{data.trackingNumber}}
+Status: {{data.status}}
+Carrier: {{data.carrier}}
+
+Please check for updates.

--- a/.knock/workflows/shipment-exception/workflow.json
+++ b/.knock/workflows/shipment-exception/workflow.json
@@ -1,0 +1,25 @@
+{
+  "name": "Shipment Exception",
+  "steps": [
+    {
+      "channel_key": "in-app",
+      "channel_type": "in_app_feed",
+      "name": "In-app notification",
+      "ref": "in_app_notification",
+      "template": {
+        "action_url": "/shipments/{{data.trackingNumber}}",
+        "markdown_body@": "in_app_notification/markdown_body.md"
+      },
+      "type": "channel"
+    }
+  ],
+  "trigger_frequency": "every_trigger",
+  "__readonly": {
+    "environment": "development",
+    "key": "shipment-exception",
+    "active": true,
+    "valid": true,
+    "created_at": "2026-02-14T00:48:25.156295Z"
+  },
+  "$schema": "https://schemas.knock.app/cli/workflow.json"
+}

--- a/.knock/workflows/shipment-status-changed/in_app_notification/markdown_body.md
+++ b/.knock/workflows/shipment-status-changed/in_app_notification/markdown_body.md
@@ -1,0 +1,5 @@
+📍 **Shipment status updated**
+
+Tracking: {{data.trackingNumber}}
+Status: {{data.previousStatus}} → **{{data.status}}**
+{{#if data.estimatedDelivery}}Expected delivery: {{data.estimatedDelivery}}{{/if}}

--- a/.knock/workflows/shipment-status-changed/workflow.json
+++ b/.knock/workflows/shipment-status-changed/workflow.json
@@ -1,0 +1,25 @@
+{
+  "name": "Shipment Status Changed",
+  "steps": [
+    {
+      "channel_key": "in-app",
+      "channel_type": "in_app_feed",
+      "name": "In-app notification",
+      "ref": "in_app_notification",
+      "template": {
+        "action_url": "/shipments/{{data.trackingNumber}}",
+        "markdown_body@": "in_app_notification/markdown_body.md"
+      },
+      "type": "channel"
+    }
+  ],
+  "trigger_frequency": "every_trigger",
+  "__readonly": {
+    "environment": "development",
+    "key": "shipment-status-changed",
+    "active": true,
+    "valid": true,
+    "created_at": "2026-02-14T00:48:25.649782Z"
+  },
+  "$schema": "https://schemas.knock.app/cli/workflow.json"
+}

--- a/knock.json
+++ b/knock.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://schemas.knock.app/cli/knock.json",
+  "knockDir": ".knock"
+}


### PR DESCRIPTION
## Summary
Adds Knock workflow definitions as code, enabling version control and CI/CD for notification templates.

## Workflows Added
| Workflow | Trigger | Description |
|----------|---------|-------------|
| `shipment-created` | New shipment tracked | Welcome notification with tracking link |
| `shipment-status-changed` | Status update | Progress updates (in transit, out for delivery, etc.) |
| `shipment-delivered` | Shipment delivered | Delivery confirmation |
| `shipment-exception` | Delivery issue | Alert on delays, failed attempts, exceptions |

## Structure
```
.knock/
└── workflows/
    ├── shipment-created/
    │   ├── workflow.json
    │   └── in_app_notification/markdown_body.md
    ├── shipment-delivered/
    ├── shipment-exception/
    └── shipment-status-changed/
knock.json
```

## Usage
- Edit workflows locally, then `knock workflow push` to deploy
- Pull changes from dashboard with `knock workflow pull`
- Requires `KNOCK_API_KEY` env var

## Related
- Builds on PR #25 (Knock DDD infrastructure)