### PR TITLE
feat(auth): Add frontend authentication and route protection

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,53 @@
+import { auth0 } from '@/lib/auth0'
+import { redirect } from 'next/navigation'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Package } from 'lucide-react'
+
+interface LoginPageProps {
+  searchParams: Promise<{ returnTo?: string }>
+}
+
+/**
+ * Login page for unauthenticated users.
+ * Redirects to dashboard if already logged in.
+ */
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  // Check if user is already authenticated
+  const session = await auth0.getSession()
+
+  if (session) {
+    // Already logged in, redirect to dashboard or returnTo
+    const params = await searchParams
+    redirect(params.returnTo ?? '/')
+  }
+
+  const params = await searchParams
+  const returnTo = params.returnTo ?? '/'
+
+  return (
+    <main className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+            <Package className="h-6 w-6 text-primary" />
+          </div>
+          <CardTitle className="text-2xl">Shipment Tracking</CardTitle>
+          <CardDescription>
+            Sign in to access your shipment dashboard
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <a
+            href={`/auth/login?returnTo=${encodeURIComponent(returnTo)}`}
+            className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 w-full"
+          >
+            Sign in with Auth0
+          </a>
+          <p className="text-center text-xs text-muted-foreground">
+            By signing in, you agree to our terms of service and privacy policy.
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from 'react'
 import ShipmentTable from '@/components/ShipmentTable'
 import StatusTabs from '@/components/StatusTabs'
-import LastSyncDisplay from '@/components/LastSyncDisplay'
 import StaleDataBanner from '@/components/StaleDataBanner'
 import TableSkeleton from '@/components/TableSkeleton'
+import { DashboardHeader } from '@/components/DashboardHeader'
 import { getShipments, type ShipmentQueryParams } from '@/lib/data/shipments'
 
 interface PageProps {
@@ -36,20 +36,8 @@ export default async function Home({ searchParams }: PageProps) {
   return (
     <main className="min-h-screen bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-start justify-between">
-            <div>
-              <h1 className="text-3xl font-bold tracking-tight">
-                Shipment Tracking Dashboard
-              </h1>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Monitor all shipments and tracking status
-              </p>
-            </div>
-            <LastSyncDisplay />
-          </div>
-        </div>
+        {/* Header with User Menu */}
+        <DashboardHeader />
 
         {/* Stale Data Warning */}
         <StaleDataBanner />

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,13 +1,17 @@
 import { getCurrentUser } from '@/lib/auth'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
 import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { LogoutButton } from '@/components/auth'
 
 export default async function ProfilePage() {
   const user = await getCurrentUser()
 
   if (!user) {
-    redirect('/api/auth/login')
+    redirect('/auth/login')
   }
 
   const initials = user.name
@@ -18,37 +22,53 @@ export default async function ProfilePage() {
     .slice(0, 2) ?? 'U'
 
   return (
-    <div className="container mx-auto py-8">
-      <Card className="max-w-md mx-auto">
-        <CardHeader className="text-center">
-          <Avatar className="h-20 w-20 mx-auto mb-4">
-            <AvatarImage src={user.picture ?? undefined} alt={user.name ?? 'User'} />
-            <AvatarFallback className="text-2xl">{initials}</AvatarFallback>
-          </Avatar>
-          <CardTitle>{user.name}</CardTitle>
-          <CardDescription>{user.email}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <dl className="space-y-4 text-sm">
-            <div>
-              <dt className="font-medium text-muted-foreground">User ID</dt>
-              <dd className="mt-1 font-mono text-xs break-all">{user.sub}</dd>
+    <main className="min-h-screen bg-background">
+      <div className="container mx-auto py-8">
+        {/* Back to dashboard link */}
+        <div className="mb-6">
+          <Button asChild variant="ghost" size="sm">
+            <Link href="/">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Dashboard
+            </Link>
+          </Button>
+        </div>
+
+        <Card className="max-w-md mx-auto">
+          <CardHeader className="text-center">
+            <Avatar className="h-20 w-20 mx-auto mb-4">
+              <AvatarImage src={user.picture ?? undefined} alt={user.name ?? 'User'} />
+              <AvatarFallback className="text-2xl">{initials}</AvatarFallback>
+            </Avatar>
+            <CardTitle>{user.name}</CardTitle>
+            <CardDescription>{user.email}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <dl className="space-y-4 text-sm">
+              <div>
+                <dt className="font-medium text-muted-foreground">User ID</dt>
+                <dd className="mt-1 font-mono text-xs break-all">{user.sub}</dd>
+              </div>
+              {user.email_verified !== undefined && (
+                <div>
+                  <dt className="font-medium text-muted-foreground">Email Verified</dt>
+                  <dd className="mt-1">{user.email_verified ? 'Yes' : 'No'}</dd>
+                </div>
+              )}
+              {user.updated_at && (
+                <div>
+                  <dt className="font-medium text-muted-foreground">Last Updated</dt>
+                  <dd className="mt-1">{new Date(user.updated_at).toLocaleString()}</dd>
+                </div>
+              )}
+            </dl>
+
+            <div className="pt-4 border-t">
+              <LogoutButton variant="destructive" className="w-full" />
             </div>
-            {user.email_verified !== undefined && (
-              <div>
-                <dt className="font-medium text-muted-foreground">Email Verified</dt>
-                <dd className="mt-1">{user.email_verified ? 'Yes' : 'No'}</dd>
-              </div>
-            )}
-            {user.updated_at && (
-              <div>
-                <dt className="font-medium text-muted-foreground">Last Updated</dt>
-                <dd className="mt-1">{new Date(user.updated_at).toLocaleString()}</dd>
-              </div>
-            )}
-          </dl>
-        </CardContent>
-      </Card>
-    </div>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
   )
 }

--- a/components/DashboardHeader.tsx
+++ b/components/DashboardHeader.tsx
@@ -1,0 +1,26 @@
+import { UserMenu } from '@/components/auth'
+import LastSyncDisplay from '@/components/LastSyncDisplay'
+
+/**
+ * Dashboard header with title, last sync time, and user menu.
+ */
+export function DashboardHeader() {
+  return (
+    <header className="mb-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Shipment Tracking Dashboard
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Monitor all shipments and tracking status
+          </p>
+        </div>
+        <div className="flex items-center gap-4">
+          <LastSyncDisplay />
+          <UserMenu />
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,22 +1,58 @@
-import type { NextRequest } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 import { auth0 } from './lib/auth0'
 
 /**
- * Auth0 middleware.
- * 
- * Handles authentication routes and session management.
- * Routes:
- * - /auth/login    - Redirects to Auth0 login
- * - /auth/logout   - Logs user out
- * - /auth/callback - Handles Auth0 callback
+ * Public routes that don't require authentication.
+ * - /auth/* - Auth0 routes (login, logout, callback)
+ * - /api/webhooks/* - Webhook endpoints
+ * - /login - Login page for unauthenticated users
+ */
+const PUBLIC_ROUTES = ['/auth', '/api/webhooks', '/login']
+
+/**
+ * Check if a path is a public route.
+ */
+function isPublicRoute(pathname: string): boolean {
+  return PUBLIC_ROUTES.some((route) => pathname.startsWith(route))
+}
+
+/**
+ * Auth0 middleware with route protection.
+ *
+ * - Public routes: Accessible without authentication
+ * - Protected routes: Redirects to /login if not authenticated
  */
 export async function middleware(request: NextRequest) {
-  return await auth0.middleware(request)
+  // Always run Auth0 middleware first (handles /auth/* routes, session management)
+  const authResponse = await auth0.middleware(request)
+
+  // If this is an auth route, return the auth response directly
+  if (request.nextUrl.pathname.startsWith('/auth')) {
+    return authResponse
+  }
+
+  // Public routes don't need auth check
+  if (isPublicRoute(request.nextUrl.pathname)) {
+    return authResponse
+  }
+
+  // Protected routes: check for session
+  const session = await auth0.getSession(request)
+
+  if (!session) {
+    // Redirect to login with return URL
+    const loginUrl = new URL('/login', request.url)
+    loginUrl.searchParams.set('returnTo', request.nextUrl.pathname)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  // User is authenticated, return the auth response (preserves session cookies)
+  return authResponse
 }
 
 export const config = {
   // Match all routes except static files
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|api/webhooks).*)',
+    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
 }


### PR DESCRIPTION
## Summary

Adds frontend authentication to the tracking dashboard. The main dashboard is now protected and requires authentication.

## Changes

### Middleware Route Protection
- Protected routes redirect unauthenticated users to `/login`
- Public routes: `/auth/*`, `/api/webhooks/*`, `/login`
- Preserves `returnTo` parameter for post-login redirect

### Login Page (`/login`)
- Clean login page with Auth0 redirect
- Automatically redirects authenticated users to dashboard
- Respects `returnTo` query parameter

### Dashboard Header
- Added `DashboardHeader` component with user menu
- Shows user avatar, name, and email in dropdown
- Quick access to profile and logout

### Profile Page
- Added back navigation to dashboard
- Added logout button
- Fixed redirect URL (`/api/auth/login` → `/auth/login`)

## Auth Flow

```
User visits /            → Middleware checks session
                        → No session: redirect to /login?returnTo=/
                        → Has session: render dashboard

User visits /login      → Already logged in? redirect to /
                        → Not logged in: show login page

User clicks Sign In     → Redirect to /auth/login?returnTo=/
                        → Auth0 Universal Login
                        → Callback to /auth/callback
                        → Redirect to returnTo (/)
```

## Testing

1. Visit `/` without session → should redirect to `/login`
2. Sign in via Auth0 → should return to dashboard
3. UserMenu should show in header with name/avatar
4. Profile page should show user info
5. Logout should clear session and return to login

## Dependencies

- Builds on #27 (feat/auth0-integration)
