### PR TITLE
feat(auth): Restrict access to @stitchi.co emails

### DIFF
--- a/app/unauthorized/page.tsx
+++ b/app/unauthorized/page.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { ShieldX } from 'lucide-react'
+
+/**
+ * Unauthorized page shown when a user authenticates but isn't allowed access.
+ * This happens when their email domain isn't in the allowlist.
+ */
+export default function UnauthorizedPage() {
+  return (
+    <main className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+            <ShieldX className="h-6 w-6 text-destructive" />
+          </div>
+          <CardTitle className="text-2xl">Access Denied</CardTitle>
+          <CardDescription>
+            You don&apos;t have permission to access this application.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground text-center">
+            This application is restricted to authorized Stitchi team members.
+            If you believe you should have access, please contact your administrator.
+          </p>
+          <Button asChild variant="outline" className="w-full">
+            <a href="/auth/logout">Sign out and try a different account</a>
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Restricts dashboard access to Stitchi team members only by checking email domain.

## Changes

### Middleware
- Added `ALLOWED_EMAIL_DOMAINS = ['stitchi.co']` allowlist
- After authentication, checks if user's email domain is allowed
- Redirects unauthorized users to `/unauthorized`

### Unauthorized Page
- New `/unauthorized` page for users who authenticate but aren't allowed
- Shows "Access Denied" message
- Provides logout button to try a different account

## Auth Flow

```
User authenticates via Auth0
        ↓
Middleware checks email domain
        ↓
@stitchi.co? → Dashboard ✅
Other domain? → /unauthorized ❌
```

## Testing

1. Sign in with a @stitchi.co email → should access dashboard
2. Sign in with any other email → should see "Access Denied" page
3. Click "Sign out" on unauthorized page → should return to login

## Note

Also recommended: Disable public sign-ups in Auth0 Dashboard:
- Authentication → Database → Username-Password-Authentication
- Toggle **Disable Sign Ups** = ON
