### PR TITLE
feat: Thread review UI and management endpoints

### DIFF
--- a/components/ThreadReviewQueue.tsx
+++ b/components/ThreadReviewQueue.tsx
@@ -50,8 +50,8 @@ interface PendingReviewItem {
     confidenceScore: number
     matchStatus: string
     emailMatched: boolean
-    poInSubject: boolean
-    poInBody: boolean
+    orderInSubject: boolean
+    orderInBody: boolean
     daysSinceLastMessage: number | null
     matchedEmail: string | null
     conversationSubject: string | null
@@ -363,16 +363,16 @@ export default function ThreadReviewQueue() {
                               )}
                             </div>
                             <div>
-                              <span className="text-muted-foreground">PO in Subject:</span>{' '}
-                              {item.threadLink.poInSubject ? (
+                              <span className="text-muted-foreground">Order in Subject:</span>{' '}
+                              {item.threadLink.orderInSubject ? (
                                 <Badge variant="default" className="bg-green-500 ml-1">Yes</Badge>
                               ) : (
                                 <Badge variant="secondary" className="ml-1">No</Badge>
                               )}
                             </div>
                             <div>
-                              <span className="text-muted-foreground">PO in Body:</span>{' '}
-                              {item.threadLink.poInBody ? (
+                              <span className="text-muted-foreground">Order in Body:</span>{' '}
+                              {item.threadLink.orderInBody ? (
                                 <Badge variant="default" className="bg-green-500 ml-1">Yes</Badge>
                               ) : (
                                 <Badge variant="secondary" className="ml-1">No</Badge>

--- a/lib/infrastructure/customer-thread/PrismaCustomerThreadRepository.ts
+++ b/lib/infrastructure/customer-thread/PrismaCustomerThreadRepository.ts
@@ -20,8 +20,8 @@ function toDomain(record: {
   confidence_score: number
   match_status: string
   email_matched: boolean
-  po_in_subject: boolean
-  po_in_body: boolean
+  order_in_subject: boolean
+  order_in_body: boolean
   days_since_last_message: number | null
   matched_email: string | null
   conversation_subject: string | null
@@ -37,8 +37,8 @@ function toDomain(record: {
     confidenceScore: record.confidence_score,
     matchStatus: record.match_status as ThreadMatchStatusType,
     emailMatched: record.email_matched,
-    poInSubject: record.po_in_subject,
-    poInBody: record.po_in_body,
+    orderInSubject: record.order_in_subject,
+    orderInBody: record.order_in_body,
     daysSinceLastMessage: record.days_since_last_message,
     matchedEmail: record.matched_email,
     conversationSubject: record.conversation_subject,
@@ -75,8 +75,8 @@ export function createPrismaCustomerThreadRepository(
           confidence_score: input.confidenceScore,
           match_status: toPrismaStatus(input.matchStatus),
           email_matched: input.emailMatched,
-          po_in_subject: input.poInSubject,
-          po_in_body: input.poInBody,
+          order_in_subject: input.orderInSubject,
+          order_in_body: input.orderInBody,
           days_since_last_message: input.daysSinceLastMessage,
           matched_email: input.matchedEmail,
           conversation_subject: input.conversationSubject,

--- a/prisma/migrations/20260216210000_rename_po_to_order_in_threads/migration.sql
+++ b/prisma/migrations/20260216210000_rename_po_to_order_in_threads/migration.sql
@@ -1,0 +1,9 @@
+-- Rename PO columns to ORDER columns
+-- PO number is internal (supplier-facing), Order number is customer-facing
+-- Thread matching should use order number, not PO number
+
+ALTER TABLE "shipment_customer_threads" 
+  RENAME COLUMN "po_in_subject" TO "order_in_subject";
+
+ALTER TABLE "shipment_customer_threads" 
+  RENAME COLUMN "po_in_body" TO "order_in_body";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,9 +202,9 @@ model shipment_customer_threads {
   match_status          ThreadMatchStatus @default(pending_review)
   
   // Scoring breakdown (for debugging/audit)
-  email_matched         Boolean           @default(false)
-  po_in_subject         Boolean           @default(false)
-  po_in_body            Boolean           @default(false)
+  email_matched           Boolean           @default(false)
+  order_in_subject        Boolean           @default(false)
+  order_in_body           Boolean           @default(false)
   days_since_last_message Int?
   
   // Metadata

--- a/tests/unit/domain/customer-thread/scoring.test.ts
+++ b/tests/unit/domain/customer-thread/scoring.test.ts
@@ -63,50 +63,61 @@ describe('calculateConfidenceScore', () => {
     })
   })
 
-  describe('PO number in subject', () => {
-    it('should match exact PO number in subject', () => {
+  describe('order number in subject', () => {
+    it('should match exact order number in subject', () => {
       const candidate: ConversationCandidate = {
         ...baseCandidate,
-        subject: 'Re: Order 164-1 - Shipping Update',
+        subject: 'Re: Order 164 - Shipping Update',
       }
 
-      const result = calculateConfidenceScore(candidate, null, '164-1')
+      const result = calculateConfidenceScore(candidate, null, '164')
 
-      expect(result.breakdown.poInSubject).toBe(true)
-      expect(result.score).toBeGreaterThanOrEqual(ScoringWeights.PO_IN_SUBJECT)
+      expect(result.breakdown.orderInSubject).toBe(true)
+      expect(result.score).toBeGreaterThanOrEqual(ScoringWeights.ORDER_IN_SUBJECT)
     })
 
-    it('should match PO with prefix', () => {
+    it('should match order with "order" prefix', () => {
       const candidate: ConversationCandidate = {
         ...baseCandidate,
-        subject: 'PO 164-1 Ready for Shipment',
+        subject: 'Order 164 Ready for Shipment',
       }
 
-      const result = calculateConfidenceScore(candidate, null, '164-1')
+      const result = calculateConfidenceScore(candidate, null, '164')
 
-      expect(result.breakdown.poInSubject).toBe(true)
+      expect(result.breakdown.orderInSubject).toBe(true)
     })
 
-    it('should match PO# prefix', () => {
+    it('should match order# prefix', () => {
       const candidate: ConversationCandidate = {
         ...baseCandidate,
-        subject: 'PO#164-1 Tracking',
+        subject: 'Order#164 Tracking',
       }
 
-      const result = calculateConfidenceScore(candidate, null, '164-1')
+      const result = calculateConfidenceScore(candidate, null, '164')
 
-      expect(result.breakdown.poInSubject).toBe(true)
+      expect(result.breakdown.orderInSubject).toBe(true)
     })
 
-    it('should not match if PO not in subject', () => {
+    it('should match #number format', () => {
+      const candidate: ConversationCandidate = {
+        ...baseCandidate,
+        subject: 'Your #164 has shipped!',
+      }
+
+      const result = calculateConfidenceScore(candidate, null, '164')
+
+      expect(result.breakdown.orderInSubject).toBe(true)
+    })
+
+    it('should not match if order number not in subject', () => {
       const candidate: ConversationCandidate = {
         ...baseCandidate,
         subject: 'General Inquiry',
       }
 
-      const result = calculateConfidenceScore(candidate, null, '164-1')
+      const result = calculateConfidenceScore(candidate, null, '164')
 
-      expect(result.breakdown.poInSubject).toBe(false)
+      expect(result.breakdown.orderInSubject).toBe(false)
     })
 
     it('should handle null subject', () => {
@@ -115,9 +126,9 @@ describe('calculateConfidenceScore', () => {
         subject: null,
       }
 
-      const result = calculateConfidenceScore(candidate, null, '164-1')
+      const result = calculateConfidenceScore(candidate, null, '164')
 
-      expect(result.breakdown.poInSubject).toBe(false)
+      expect(result.breakdown.orderInSubject).toBe(false)
     })
   })
 
@@ -182,10 +193,10 @@ describe('calculateConfidenceScore', () => {
   })
 
   describe('combined scoring', () => {
-    it('should combine email match + PO in subject for high score', () => {
+    it('should combine email match + order in subject for high score', () => {
       const candidate: ConversationCandidate = {
         conversationId: 'cnv_123',
-        subject: 'Re: PO 164-1 - Tracking Update',
+        subject: 'Re: Order 164 - Tracking Update',
         lastMessageAt: new Date(),
         participants: ['customer@example.com'],
       }
@@ -193,19 +204,19 @@ describe('calculateConfidenceScore', () => {
       const result = calculateConfidenceScore(
         candidate,
         'customer@example.com',
-        '164-1'
+        '164'
       )
 
       // 0.4 (email) + 0.4 (subject) + ~0.1 (recency) = ~0.9
       expect(result.score).toBeGreaterThanOrEqual(0.8)
       expect(result.breakdown.emailMatched).toBe(true)
-      expect(result.breakdown.poInSubject).toBe(true)
+      expect(result.breakdown.orderInSubject).toBe(true)
     })
 
     it('should cap score at 1.0', () => {
       const candidate: ConversationCandidate = {
         conversationId: 'cnv_123',
-        subject: 'PO 164-1 PO 164-1 PO 164-1', // Repeated
+        subject: 'Order 164 Order 164 Order 164', // Repeated
         lastMessageAt: new Date(),
         participants: ['customer@example.com'],
       }
@@ -213,7 +224,7 @@ describe('calculateConfidenceScore', () => {
       const result = calculateConfidenceScore(
         candidate,
         'customer@example.com',
-        '164-1'
+        '164'
       )
 
       expect(result.score).toBeLessThanOrEqual(1)


### PR DESCRIPTION
## Summary

Adds UI and API endpoints for manually reviewing and managing customer thread matches.

> **Note:** This PR is based on `feat/customer-thread-discovery` (PR #44). Merge #44 first.

## New oRPC Endpoints

| Endpoint | Description |
|----------|-------------|
| `customerThread.getPendingReviews` | List shipments with pending_review thread matches |
| `customerThread.approve` | Accept a thread match (→ manually_linked) |
| `customerThread.reject` | Decline a thread match (→ rejected) |
| `customerThread.linkDifferent` | Override with a different conversation |
| `customerThread.triggerDiscovery` | Manually trigger thread discovery for a shipment |
| `customerThread.getByShipment` | Get thread link for a specific shipment |
| `customerThread.searchConversations` | Search Front conversations by email |

## New Component

**`ThreadReviewQueue.tsx`** - Full review queue UI:
- Table view of pending reviews with confidence scores
- Expandable rows showing scoring breakdown (email match, PO in subject, etc.)
- Action buttons: ✅ Approve, ❌ Reject, 🔗 Link Different
- Manual link dialog with Front conversation search
- Loading/error/empty states

## Screenshot

*(Component not yet integrated into a page - will be added when wiring up the dashboard)*

## Testing

- TypeScript compiles cleanly
- All audit actions logged properly

## Next Steps (PR 5)
- Front reply capability (actually sending tracking notifications)

## Related

Part of #41 - Customer tracking notifications
- PR 1: ✅ Audit history foundation (#42)
- PR 2: ✅ OMG customer email sync (#43)  
- PR 3: 🟡 Customer thread discovery (#44) ← **base branch**
- **PR 4: This PR** - Thread review UI