### PR TITLE
feat: add shipment notification tracking field

### DIFF
--- a/prisma/migrations/20260217_add_shipment_notification_tracking/migration.sql
+++ b/prisma/migrations/20260217_add_shipment_notification_tracking/migration.sql
@@ -1,0 +1,6 @@
+-- Add notification tracking field to shipments
+-- Tracks the last status for which a customer notification was sent
+-- Used to prevent duplicate notifications and identify missed notifications
+-- when a thread is linked after shipment status changes
+
+ALTER TABLE "shipments" ADD COLUMN "last_notified_status" VARCHAR(50);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,12 @@ model shipments {
   ship24_status         String?               @db.VarChar(100)
   ship24_last_update    DateTime?
   tracking_events       tracking_events[]
+  
+  // Customer notification tracking
+  // Tracks the last status for which a notification was sent to prevent duplicates
+  // and identify missed notifications when a thread is linked after the fact
+  last_notified_status  String?               @db.VarChar(50)
+  
   // Note: OMG data is now joined by po_number, not by relation
   // Note: Customer thread is now stored at the order level, not shipment level
 


### PR DESCRIPTION
## Summary

Adds a `last_notified_status` field to the `shipments` table to track customer notification state.

## Changes

- **Schema**: Added `last_notified_status VARCHAR(50)` to `shipments` table
- **Migration**: SQL migration to add the column

## Purpose

This field tracks the last shipment status for which a customer notification was sent. It enables:

1. **Preventing duplicate notifications** — Don't send "shipped" notification twice
2. **Catch-up notifications** — When a thread is manually linked after a status change, we can identify which notifications were missed by comparing `status` vs `last_notified_status`

## Part of

Tracking Notifications feature (PR 1/4)

| PR | Description | Status |
|----|-------------|--------|
| **PR 1** | Schema — notification tracking field | ← This PR |
| PR 2 | Domain Events — ThreadLinked event | Pending |
| PR 3 | Handler — real-time notifications | Pending |
| PR 4 | Handler — catch-up notifications | Pending |

## Migration

Run after merge:
```bash
npx prisma migrate deploy
```