### PR TITLE
feat: add ThreadLinked domain event

### DIFF
--- a/lib/domain/events/index.ts
+++ b/lib/domain/events/index.ts
@@ -64,6 +64,15 @@ type EventPayloads = {
     created: boolean
     posCount: number
   }
+  
+  /** Emitted when a customer thread is linked to an order */
+  ThreadLinked: {
+    orderNumber: string
+    conversationId: string
+    matchType: 'auto_matched' | 'manually_linked'
+    /** Previous conversation ID if re-linking */
+    previousConversationId?: string | null
+  }
 }
 
 type EventName = keyof EventPayloads

--- a/lib/infrastructure/customer-thread/OrderThreadDiscoveryService.ts
+++ b/lib/infrastructure/customer-thread/OrderThreadDiscoveryService.ts
@@ -218,6 +218,14 @@ export function createOrderThreadDiscoveryService(
             searchMethod,
           },
         })
+        
+        // Emit domain event for catch-up notifications
+        const { domainEvents } = await import('@/lib/domain/events')
+        domainEvents.emit('ThreadLinked', {
+          orderNumber,
+          conversationId: topCandidate.conversationId,
+          matchType: 'auto_matched',
+        })
       }
 
       return {

--- a/lib/orpc/customerThreadRouter.ts
+++ b/lib/orpc/customerThreadRouter.ts
@@ -199,6 +199,14 @@ export const customerThreadRouter = {
         },
       })
       
+      // Emit domain event for catch-up notifications
+      const { domainEvents } = await import('@/lib/domain/events')
+      domainEvents.emit('ThreadLinked', {
+        orderNumber: input.orderNumber,
+        conversationId: updated.frontConversationId!,
+        matchType: 'manually_linked',
+      })
+      
       return {
         success: true,
         threadLink: {
@@ -295,6 +303,15 @@ export const customerThreadRouter = {
           previousStatus: current?.matchStatus,
           newStatus: 'manually_linked',
         },
+      })
+      
+      // Emit domain event for catch-up notifications
+      const { domainEvents } = await import('@/lib/domain/events')
+      domainEvents.emit('ThreadLinked', {
+        orderNumber: input.orderNumber,
+        conversationId: input.newConversationId,
+        matchType: 'manually_linked',
+        previousConversationId: current?.frontConversationId,
       })
       
       return {


### PR DESCRIPTION
## Summary

Adds a `ThreadLinked` domain event that fires when a customer thread is linked to an order. This enables catch-up notifications (PR 3) when a thread is linked after shipment status changes have already occurred.

## Event Payload

```typescript
ThreadLinked: {
  orderNumber: string
  conversationId: string
  matchType: 'auto_matched' | 'manually_linked'
  previousConversationId?: string | null  // for re-linking
}
```

## Emission Points

| Action | Location | Trigger |
|--------|----------|---------|
| Approve | `customerThreadRouter.approve` | User approves pending_review → manually_linked |
| Link Different | `customerThreadRouter.linkDifferent` | User manually links to different conversation |
| Auto-match | `OrderThreadDiscoveryService.discoverThread` | High confidence match (≥0.7) |

## Use Case

```
Timeline:
1. Shipment status changes to 'shipped'
2. No thread linked → notification skipped
3. User manually links thread
4. ThreadLinked event fires
5. [PR 3] Catch-up handler queries missed notifications
6. [PR 3] Triggers 'shipped' notification via Knock
```

## Part of Series

| PR | Description | Status |
|----|-------------|--------|
| ✅ PR 1 | Customer notifications via Knock | Merged |
| **PR 2** | ThreadLinked domain event | ← This PR |
| PR 3 | Catch-up notifications on thread link | Next |